### PR TITLE
Update gRPC and add GCC11 build instructions

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -10,6 +10,8 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  CC: gcc-11
+  CXX: g++-11
 
 permissions:
   contents: write

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -5,6 +5,8 @@ on: workflow_dispatch
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
+  CC: gcc-11
+  CXX: g++-11
 
 jobs:      
   buildAndTest:

--- a/AGENT.md
+++ b/AGENT.md
@@ -18,6 +18,7 @@ Create a custom profile using GCC 11:
 conan profile detect --force --name=gcc11
 sed -i 's/compiler.version=.*/compiler.version=11/' ~/.conan2/profiles/gcc11
 sed -i 's/compiler.cppstd=.*/compiler.cppstd=17/' ~/.conan2/profiles/gcc11
+echo "build_type=Release" >> ~/.conan2/profiles/gcc11
 ```
 
 ## Configure and build
@@ -28,7 +29,7 @@ export CXX=g++-11
 ```
 Configure with CMake and Conan:
 ```bash
-cmake -B build -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=${PWD}/conan_provider.cmake -DCONAN_PROFILE=gcc11
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=${PWD}/conan_provider.cmake -DCONAN_PROFILE=gcc11
 cmake --build build -j $(nproc)
 ```
 Run tests:

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,37 @@
+# Build Instructions
+
+## Dependencies
+- GCC 11 (`gcc-11`, `g++-11`)
+- Python `conan` package
+- `golang-cfssl` for certificate generation
+
+Install packages on Ubuntu:
+```bash
+sudo apt-get update
+sudo apt-get install -y gcc-11 g++-11 golang-cfssl
+pip install conan --break-system-packages
+```
+
+## Conan profile
+Create a custom profile using GCC 11:
+```bash
+conan profile detect --force --name=gcc11
+sed -i 's/compiler.version=.*/compiler.version=11/' ~/.conan2/profiles/gcc11
+sed -i 's/compiler.cppstd=.*/compiler.cppstd=17/' ~/.conan2/profiles/gcc11
+```
+
+## Configure and build
+Set environment variables so CMake and Conan use GCC 11:
+```bash
+export CC=gcc-11
+export CXX=g++-11
+```
+Configure with CMake and Conan:
+```bash
+cmake -B build -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=${PWD}/conan_provider.cmake -DCONAN_PROFILE=gcc11
+cmake --build build -j $(nproc)
+```
+Run tests:
+```bash
+ctest --test-dir build
+```

--- a/C2Client/requirements.txt
+++ b/C2Client/requirements.txt
@@ -1,5 +1,5 @@
 pycryptodome
-grpcio==1.66.1
+grpcio==1.72.0
 PyQt5
 pyqtdarktheme
 protobuf==5.27.0

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-protobuf/6.30.1
+protobuf/5.27.0
 abseil/20240116.2
 openssl/3.5.1
 zlib/1.3.1 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,11 +1,11 @@
 [requires]
-protobuf/5.27.0
+protobuf/6.30.1
 abseil/20240116.2
-openssl/3.4.1 
+openssl/3.5.1
 zlib/1.3.1 
 grpc/1.72.0
 spdlog/1.15.1
-cpp-httplib/0.19.0
+cpp-httplib/0.20.1
 
 [layout]
 cmake_layout

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -3,7 +3,7 @@ protobuf/5.27.0
 abseil/20240116.2
 openssl/3.4.1 
 zlib/1.3.1 
-grpc/1.67.1
+grpc/1.72.0
 spdlog/1.15.1
 cpp-httplib/0.19.0
 


### PR DESCRIPTION
## Summary
- require grpc 1.72 in `conanfile.txt`
- bump grpcio Python dependency to 1.72.0
- set `CC` and `CXX` to gcc‑11 in CI workflows
- document GCC 11 build steps in new `AGENT.md`

## Testing
- `apt-get install -y gcc-11 g++-11` succeeded
- `pip install conan --break-system-packages` succeeded
- `cmake -B build -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=$PWD/conan_provider.cmake -DCONAN_PROFILE=gcc11` started downloading dependencies but halted due to source builds and network restrictions


------
https://chatgpt.com/codex/tasks/task_e_68891b2f181883259da8e50d401846ce