### PR TITLE
Fix C2Client tests and refresh dependencies

### DIFF
--- a/C2Client/pyproject.toml
+++ b/C2Client/pyproject.toml
@@ -8,15 +8,21 @@ version = "0.1.0"
 dependencies = [
     "setuptools",
     "pycryptodome==3.23.0",
-    "grpcio==1.66.1",
+    "grpcio==1.74.0",
     "PyQt5==5.15.11",
     "pyqtdarktheme==2.1.0",
-    "protobuf==5.27.0",
+    "protobuf==6.32.0",
     "gitpython==3.1.45",
     "requests==2.32.5",
     "pwn==1.0",
     "pefile==2024.8.26",
     "openai==1.102.0"
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest==8.4.1",
+    "pytest-qt==4.5.0"
 ]
 
 [tool.setuptools.packages.find]

--- a/C2Client/requirements.txt
+++ b/C2Client/requirements.txt
@@ -1,10 +1,12 @@
 pycryptodome==3.23.0
-grpcio==1.66.1
+grpcio==1.74.0
 PyQt5==5.15.11
 pyqtdarktheme==2.1.0
-protobuf==5.27.0
+protobuf==6.32.0
 gitpython==3.1.45
 requests==2.32.5
 pwn==1.0
 pefile==2024.8.26
 openai==1.102.0
+pytest==8.4.1
+pytest-qt==4.5.0

--- a/C2Client/tests/conftest.py
+++ b/C2Client/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")


### PR DESCRIPTION
## Summary
- update gRPC and Protobuf versions and add pytest tooling
- configure Qt for headless test runs

## Testing
- `cd C2Client && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6e08ddd088325885e143c7bc252ee